### PR TITLE
Changed gitignore file to ignore katalog json files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 __pycache__
 pb_tool.cfg_202406040_rett
-LICENSE.txt
-Data.json
+LICENSE
+
+# Ignore all catalog JSON files in root of directory
+katalog*.json


### PR DESCRIPTION
Aktuell werden die JSON-Dateien, die von QGIS in den Ordner heruntergeladen werden, ins Repository hochgeladen. 
Da diese Dateien mit "katalog" anfangen, werden sie nicht mit dem gitignore Eintrag "Data.json" registriert.
Dieser PR ändert den "Data.json" Eintrag zu "katalog*.json". Dadurch werden die JSON Kataloge nicht ins Repository hochgeladen.

Zusätzlich wurde die "txt" Endung von der Lizenz entfernt, da die tatsächliche Datei keine Endung besitzt. 