### PR TITLE
Automatic spatial bookmark on load

### DIFF
--- a/resources/design_files/preset_dialog.ui
+++ b/resources/design_files/preset_dialog.ui
@@ -84,7 +84,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="automatic_spatial_bookmark_checkBox">
+    <widget class="QCheckBox" name="automatic_spatial_bookmark_checkbox">
      <property name="text">
       <string>Automatisch existierendes räumliches Lesezeichen laden</string>
      </property>

--- a/resources/design_files/preset_dialog.ui
+++ b/resources/design_files/preset_dialog.ui
@@ -32,13 +32,13 @@
    <item>
     <layout class="QFormLayout" name="formLayout">
      <property name="fieldGrowthPolicy">
-      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+      <enum>QFormLayout::FieldGrowthPolicy::AllNonFixedFieldsGrow</enum>
      </property>
      <property name="labelAlignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+      <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
      </property>
      <property name="formAlignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+      <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
      </property>
      <item row="0" column="0">
       <widget class="QLabel" name="title_label">
@@ -60,7 +60,7 @@
         <string>Beschreibung:</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+        <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
        </property>
       </widget>
      </item>
@@ -93,10 +93,10 @@
    <item>
     <widget class="QFrame" name="hint_frame">
      <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
+      <enum>QFrame::Shape::StyledPanel</enum>
      </property>
      <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
+      <enum>QFrame::Shadow::Raised</enum>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <property name="leftMargin">
@@ -117,7 +117,7 @@
          <string>Hinweis: Die exakte Anordnung der Ebenen ist beim Laden des Presets nicht garantiert. Die Layer werden dem Projekt flach hinzugefügt und nicht in einer benutzerdefinierten Gruppenstruktur.</string>
         </property>
         <property name="textFormat">
-         <enum>Qt::PlainText</enum>
+         <enum>Qt::TextFormat::PlainText</enum>
         </property>
         <property name="wordWrap">
          <bool>true</bool>
@@ -130,10 +130,10 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
      </property>
     </widget>
    </item>

--- a/resources/design_files/preset_dialog.ui
+++ b/resources/design_files/preset_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>402</width>
-    <height>272</height>
+    <height>351</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -80,6 +80,13 @@
      </property>
      <property name="checked">
       <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="automatic_spatial_bookmark_checkBox">
+     <property name="text">
+      <string>Automatisch existierendes räumliches Lesezeichen laden</string>
      </property>
     </widget>
    </item>

--- a/src/services/preset_service.py
+++ b/src/services/preset_service.py
@@ -27,6 +27,7 @@ class Preset:
     modified: datetime = field(default_factory=datetime.now)
     entries: list[Entry] = field(default_factory=list)
     spatial_bookmark_id: Optional[str] = None
+    automatic_spatial_bookmark: bool = False
     
     def __contains__(self, item) -> bool:
         if isinstance(item, (catalog_types.Topic, catalog_types.TopicGroup, catalog_types.TopicCombination)):
@@ -96,6 +97,7 @@ class Preset:
             # FIXME: A bit convoluted; Better with utc and replace or even better datetime.UTC but only 3.11+
             "modified": self.modified.isoformat(timespec="seconds") + "Z",
             "spatial_bookmark_id": self.spatial_bookmark_id,
+            "automatic_spatial_bookmark": self.automatic_spatial_bookmark,
             "entries": self.entries,
         }
     
@@ -120,7 +122,8 @@ class Preset:
             description=data.get("description"),
             modified=modified,
             entries=data.get("entries", []),
-            spatial_bookmark_id=spatial_bookmark_id
+            spatial_bookmark_id=spatial_bookmark_id,
+            automatic_spatial_bookmark=data.get("automatic_spatial_bookmark", False)
         )
 
 class PresetManager:

--- a/src/services/preset_service.py
+++ b/src/services/preset_service.py
@@ -210,6 +210,9 @@ class PresetManager:
             if not success:
                 failures += 1
         
+        if preset.automatic_spatial_bookmark:
+            self.apply_preset_spatial_bookmark(preset)
+        
         if failures == 0:
             logger.success(f"Preset '{preset.title}' erfolgreich geladen", extra={"show_banner": True})
         else:

--- a/src/services/preset_service.py
+++ b/src/services/preset_service.py
@@ -214,6 +214,16 @@ class PresetManager:
             logger.success(f"Preset '{preset.title}' erfolgreich geladen", extra={"show_banner": True})
         else:
             logger.warning(f"Preset '{preset.title}' teilweise geladen: {failures}/{len(preset.entries)} Themen konnten nicht geladen werden", extra={"show_banner": True})
+    
+    def apply_preset_spatial_bookmark(self, preset: Preset) -> None:
+        bookmark = preset.get_spatial_bookmark()
+        if not bookmark:
+            if preset.spatial_bookmark_id:
+                logger.error(f"Räumliches Lesezeichen für Preset '{preset.title}' nicht gefunden. Anwenden nicht möglich.")
+            return
+        
+        helpers.apply_spatial_bookmark(bookmark)
+        logger.success(f"Räumliches Lesezeichen für Preset '{preset.title}' angewendet.")
 
     def get_user_presets(self) -> list[Preset]:
         return list(self.user_presets.values())

--- a/src/ui/context_menus.py
+++ b/src/ui/context_menus.py
@@ -83,14 +83,7 @@ class PresetContextMenu(QMenu):
         events.emit_presets_updated()
     
     def _apply_spatial_bookmark(self) -> None:
-        bookmark = self.preset.get_spatial_bookmark()
-        if not bookmark:
-            if self.preset.spatial_bookmark_id:
-                logger.error(f"Räumliches Lesezeichen für Preset '{self.preset.title}' nicht gefunden. Anwenden nicht möglich.")
-            return
-        
-        helpers.apply_spatial_bookmark(bookmark)
-        logger.success(f"Räumliches Lesezeichen für Preset '{self.preset.title}' angewendet.")
+        registry.preset_manager.apply_preset_spatial_bookmark(self.preset)
     
     def _create_spatial_bookmark(self) -> None:
         id = f"preset-{self.preset.id}"

--- a/src/ui/context_menus.py
+++ b/src/ui/context_menus.py
@@ -70,6 +70,7 @@ class PresetContextMenu(QMenu):
             self.preset.title, 
             self.preset.description, 
             save_crs_checkbox_visible=False, 
+            automatic_spatial_bookmark=self.preset.automatic_spatial_bookmark,
             parent=parent
         )
         if preset_dialog.exec() != PresetDialog.DialogCode.Accepted:
@@ -77,6 +78,7 @@ class PresetContextMenu(QMenu):
         
         self.preset.title = preset_dialog.preset_title
         self.preset.description = preset_dialog.preset_description
+        self.preset.automatic_spatial_bookmark = preset_dialog.automatic_spatial_bookmark
         registry.preset_manager.save_user_presets()
         events.emit_presets_updated()
     

--- a/src/ui/dialogs/preset_dialog.py
+++ b/src/ui/dialogs/preset_dialog.py
@@ -5,7 +5,7 @@ from ... import config
 PRESET_DIALOG = uic.loadUiType(config.RESOURCES_DIR / "design_files" / "preset_dialog.ui")[0]
 
 class PresetDialog(QtWidgets.QDialog, PRESET_DIALOG):
-    def __init__(self, preset_title: str = "", preset_description: Optional[str] = "", save_layer_crs: bool = False, save_crs_checkbox_visible: bool = True, parent = None):
+    def __init__(self, preset_title: str = "", preset_description: Optional[str] = "", save_layer_crs: bool = False, save_crs_checkbox_visible: bool = True, automatic_spatial_bookmark: bool = False, parent = None):
         QtWidgets.QDialog.__init__(self, parent)
         self.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose, True)
         self.setupUi(self)
@@ -16,11 +16,13 @@ class PresetDialog(QtWidgets.QDialog, PRESET_DIALOG):
         self.preset_title: str = preset_title
         self.preset_description: Optional[str] = preset_description if preset_description is not None else ""
         self.save_layer_crs: bool = save_layer_crs or save_crs_checkbox_visible
+        self.automatic_spatial_bookmark: bool = automatic_spatial_bookmark
         
         # Type hints for UI elements
         self.description_edit: QtWidgets.QPlainTextEdit = self.description_edit
         self.title_edit: QtWidgets.QLineEdit = self.title_edit
         self.save_layer_crs_checkbox: QtWidgets.QCheckBox = self.save_layer_crs_checkbox
+        self.automatic_spatial_bookmark_checkbox: QtWidgets.QCheckBox = self.automatic_spatial_bookmark_checkbox
         self.hint_label: QtWidgets.QLabel = self.hint_label
         
         # Default values
@@ -28,6 +30,7 @@ class PresetDialog(QtWidgets.QDialog, PRESET_DIALOG):
         self.description_edit.setPlainText(preset_description)
         self.save_layer_crs_checkbox.setChecked(save_layer_crs)
         self.save_layer_crs_checkbox.setVisible(save_crs_checkbox_visible)
+        self.automatic_spatial_bookmark_checkbox.setChecked(automatic_spatial_bookmark)
         
         self.buttonBox.accepted.connect(self.confirm_options)
     
@@ -35,6 +38,7 @@ class PresetDialog(QtWidgets.QDialog, PRESET_DIALOG):
         title = self.title_edit.text().strip()
         description = self.description_edit.toPlainText()
         save_layer_crs = self.save_layer_crs_checkbox.isChecked()
+        automatic_spatial_bookmark = self.automatic_spatial_bookmark_checkbox.isChecked()
         
         if not title:
             QtWidgets.QMessageBox.warning(self, "Ungültiger Titel", "Der Titel darf nicht leer sein.")
@@ -43,4 +47,5 @@ class PresetDialog(QtWidgets.QDialog, PRESET_DIALOG):
         self.preset_title = title
         self.preset_description = description if description else None
         self.save_layer_crs = save_layer_crs
+        self.automatic_spatial_bookmark = automatic_spatial_bookmark
         self.accept()


### PR DESCRIPTION
This pull request introduces a new feature that allows users to automatically apply an existing spatial bookmark when loading a preset. It updates both the user interface and the backend logic to support this option, and also modernizes some enum usage in the UI design file for better compatibility and clarity.

**New feature: Automatic spatial bookmark application**
- Added a new `automatic_spatial_bookmark` boolean field to the `Preset` data model, serialization, and deserialization logic in `preset_service.py`, enabling presets to optionally auto-apply their spatial bookmark. [[1]](diffhunk://#diff-eb695dd537757da6e07a162537f47dc75271930142c0b5f6e150456925b18e68R30) [[2]](diffhunk://#diff-eb695dd537757da6e07a162537f47dc75271930142c0b5f6e150456925b18e68R100) [[3]](diffhunk://#diff-eb695dd537757da6e07a162537f47dc75271930142c0b5f6e150456925b18e68L123-R126)
- Updated the logic in `PresetManager` to check this new field and apply the spatial bookmark automatically when loading a preset. Extracted bookmark application into a dedicated method for reuse.

**User interface updates**
- Modified the preset dialog UI (`preset_dialog.ui`) to include a new checkbox labeled "Automatisch existierendes räumliches Lesezeichen laden" for toggling the new feature, and updated enum usage for Qt compatibility. [[1]](diffhunk://#diff-7759e897b68d2fc004b80d95f488bb26f8964346f6469652c53a89fef4f07952L10-R10) [[2]](diffhunk://#diff-7759e897b68d2fc004b80d95f488bb26f8964346f6469652c53a89fef4f07952L35-R41) [[3]](diffhunk://#diff-7759e897b68d2fc004b80d95f488bb26f8964346f6469652c53a89fef4f07952L63-R63) [[4]](diffhunk://#diff-7759e897b68d2fc004b80d95f488bb26f8964346f6469652c53a89fef4f07952R86-R99) [[5]](diffhunk://#diff-7759e897b68d2fc004b80d95f488bb26f8964346f6469652c53a89fef4f07952L113-R120) [[6]](diffhunk://#diff-7759e897b68d2fc004b80d95f488bb26f8964346f6469652c53a89fef4f07952L126-R136)
- Updated the `PresetDialog` class to handle the new checkbox, passing its value through the dialog workflow and storing it in the preset. [[1]](diffhunk://#diff-1f6587b118e5aefde4265de6fa958f4880da077820a1423429d34828446e1e49L8-R8) [[2]](diffhunk://#diff-1f6587b118e5aefde4265de6fa958f4880da077820a1423429d34828446e1e49R19-R41) [[3]](diffhunk://#diff-1f6587b118e5aefde4265de6fa958f4880da077820a1423429d34828446e1e49R50)
- Ensured that when renaming a preset or editing its properties, the automatic spatial bookmark option is preserved and editable.

**Code refactoring**
- Refactored spatial bookmark application logic in context menus to use the new centralized `apply_preset_spatial_bookmark` method, improving maintainability.